### PR TITLE
Add Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM openjdk:8-jdk-alpine
+ARG JAR_FILE=./target/t34TermProject-1.0-SNAPSHOT.jar
+COPY ${JAR_FILE} app.jar
+ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
The dockerfile runs target/t34TermProject-1.0-SNAPSHOT.jar, which is the
executable for the API webserver.